### PR TITLE
Fixed modules path checking

### DIFF
--- a/tasks/beats-config.yml
+++ b/tasks/beats-config.yml
@@ -89,8 +89,8 @@
 - name: Assert modules.path presence
   assert:
     that:
-      - beat_conf.filebeat.config.modules.path is defined
-    fail_msg: 'You need to configure beat_conf.filebeat.config.modules.path for modules to be loaded'
+      - beat_conf.{{ beat }}.config.modules.path is defined
+    fail_msg: 'You need to configure beat_conf.{{ beat }}.config.modules.path for modules to be loaded'
   when: beat_modules is defined
 
 - name: Set up and configure modules


### PR DESCRIPTION
Changed checking for config modules path to be generic, depending on
specified beat.

Signed-off-by: Ladislav Macoun <ladislavmacoun@gmail.com>